### PR TITLE
Rename `mdast-contributors` to `remark-contributors`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# mdast-contributors
+# remark-contributors
 
 ![](http://img.shields.io/badge/stability-stable-orange.svg?style=flat)
-![](http://img.shields.io/npm/v/mdast-contributors.svg?style=flat)
-![](http://img.shields.io/npm/dm/mdast-contributors.svg?style=flat)
-![](http://img.shields.io/npm/l/mdast-contributors.svg?style=flat)
+![](http://img.shields.io/npm/v/remark-contributors.svg?style=flat)
+![](http://img.shields.io/npm/dm/remark-contributors.svg?style=flat)
+![](http://img.shields.io/npm/l/remark-contributors.svg?style=flat)
 
-[mdast](https://github.com/wooorm/mdast) plugin to inject a given list of contributors
+[remark](https://github.com/wooorm/remark) plugin to inject a given list of contributors
 into a table in a markdown file.
 
 Safe to be run on your `README.md` file before each commit
@@ -13,15 +13,15 @@ without creating unnecessary noise!
 
 ## Usage
 
-[![NPM](https://nodei.co/npm/mdast-contributors.png)](https://nodei.co/npm/mdast-contributors/)
+[![NPM](https://nodei.co/npm/remark-contributors.png)](https://nodei.co/npm/remark-contributors/)
 
-Used as a plugin for mdast like so:
+Used as a plugin for remark like so:
 
 ```javascript
-const plugin = require('mdast-contributors')
-const mdast  = require('mdast')
+const plugin = require('remark-contributors')
+const remark  = require('remark')
 
-readme = mdast.use(plugin, {
+readme = remark.use(plugin, {
   contributors: [
     {
       name: 'Hugh Kennedy',
@@ -73,10 +73,11 @@ properties:
 
 ## License
 
-MIT. See [LICENSE.md](http://github.com/hughsk/mdast-contributors/blob/master/LICENSE.md) for details.
+MIT. See [LICENSE.md](http://github.com/hughsk/remark-contributors/blob/master/LICENSE.md) for details.
 
 ## Contributors
 
 | Name             | GitHub                              | Twitter                                           |
 | ---------------- | ----------------------------------- | ------------------------------------------------- |
 | **Hugh Kennedy** | [hughsk](https://github.com/hughsk) | [@hughskennedy](https://twitter.com/hughskennedy) |
+| **Titus Wormer** | [wooorm](https://github.com/wooorm) | [@wooorm](https://twitter.com/wooorm)             |

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
+var toString = require('mdast-util-to-string')
+
 module.exports = contributorTableAttacher
 
-function contributorTableAttacher (mdast, opts) {
+function contributorTableAttacher (remark, opts) {
   return function contributorTableTransformer (root, file) {
     var heading  = getHeadingIndex(root.children)
     var children = root.children
@@ -104,10 +106,8 @@ function contributorTableAttacher (mdast, opts) {
     for (var i = 0; i < children.length; i++) {
       if (children[i].type !== 'heading') continue
 
-      var text = mdast.stringify({
-        children: children[i].children,
-        type: 'root'
-      }).toLowerCase()
+      var text = toString(children[i])
+        .toLowerCase()
         .replace(/[^a-z ]/g, ' ')
         .replace(/\s+/g, ' ')
         .trim()

--- a/inject.js
+++ b/inject.js
@@ -1,13 +1,14 @@
 // Uses itself to update the readme's contributors list.
 // Please add yourself here if sending through a Pull Request :)
 
-const mdast  = require('mdast')
+const remark  = require('remark')
 const fs     = require('fs')
 const plugin = require('./')
 
-fs.writeFileSync('README.md', mdast.use(plugin, {
+fs.writeFileSync('README.md', remark.use(plugin, {
   contributors: [
-    { name: 'Hugh Kennedy', github: 'hughsk', twitter: 'hughskennedy' }
+    { name: 'Hugh Kennedy', github: 'hughsk', twitter: 'hughskennedy' },
+    { name: 'Titus Wormer', github: 'wooorm', twitter: 'wooorm' }
   ]
 }).process(
   fs.readFileSync('README.md', 'utf8')

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "mdast-contributors",
+  "name": "remark-contributors",
   "version": "1.0.1",
-  "description": "mdast plugin to inject a given list of contributors into a table in a markdown file",
+  "description": "remark plugin to inject a given list of contributors into a table in a markdown file",
   "main": "index.js",
   "license": "MIT",
   "scripts": {
@@ -13,19 +13,21 @@
     "email": "hughskennedy@gmail.com",
     "url": "http://hughsk.io/"
   },
-  "dependencies": {},
+  "dependencies": {
+    "mdast-util-to-string": "^1.0.0"
+  },
   "devDependencies": {
     "diff": "^1.4.0",
-    "mdast": "^0.22.0",
+    "remark": "^3.0.0",
     "tap-spec": "^4.0.0",
     "tape": "^4.0.0"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/hughsk/mdast-contributors.git"
+    "url": "git://github.com/hughsk/remark-contributors.git"
   },
   "keywords": [
-    "mdast",
+    "remark",
     "generation",
     "inject",
     "automatic",
@@ -35,8 +37,8 @@
     "text",
     "markdown"
   ],
-  "homepage": "https://github.com/hughsk/mdast-contributors",
+  "homepage": "https://github.com/hughsk/remark-contributors",
   "bugs": {
-    "url": "https://github.com/hughsk/mdast-contributors/issues"
+    "url": "https://github.com/hughsk/remark-contributors/issues"
   }
 }


### PR DESCRIPTION
*   Rename `mdast*` to `remark*`;
*   Add `mdast-util-to-string` as a dependency, and use it to
    get the value of heading nodes, which results in faster and
    simpler stringification;
*   Add `wooorm` to the table of contributors.

You’ll still need to:

*   Rename the project on GitHub to `remark-contributors`;
*   Publish `remark-contributors` to npm;
*   Preferably update `mdast-contributors` on npm to show a deprecation message.

I’d be up for doing the last two for you if you’d give me access to npm :)

P.S. Read more about the changes [here](https://github.com/wooorm/remark/releases/tag/3.0.0).